### PR TITLE
v3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 ### Fixed
 - Fixed missing property setters in the MediaSync job that prevented the 'check for changes' feature from working properly ([e4100dc](https://github.com/pbs/pbs-media-manager-craft-kenburns/commit/e4100dc53090e2c6f20a23e6b2288d3efe9e86a9))
 
-
 ### Changed 
-- **New** media items added during a sync will always synchronize all fields, regardless of what fields were selected for sync.
+- **New** Media entries and Show entries added during a sync will always synchronize all fields, regardless of what fields were selected for sync.
 - Plugin settings no longer handles field layouts for Media or Show sections. 
 ### Added
 - Added more API attributes to the list of fields that can be synchronized to Show entries.
+- Show Entry sync jobs can now sync the Passport availability and public availability flags.
 
 ## 3.3.2 - 2023-11-02
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.3.3 - 2023-11-09
+### Fixed
+- Fixed missing property setters in the MediaSync job that prevented the 'check for changes' feature from working properly ([e4100dc](https://github.com/pbs/pbs-media-manager-craft-kenburns/commit/e4100dc53090e2c6f20a23e6b2288d3efe9e86a9))
+
+
+### Changed 
+- **New** media items added during a sync will always synchronize all fields, regardless of what fields were selected for sync.
+- Plugin settings no longer handles field layouts for Media or Show sections. 
+### Added
+- Added more API attributes to the list of fields that can be synchronized to Show entries.
+
 ## 3.3.2 - 2023-11-02
 ### Fixed
 - Fix issue where the Thumbnail field was not updating when the sync was run if it had been included in the list of fields to sync.
@@ -10,7 +21,7 @@
 ## 3.3.1 - 2023-11-02
 ### Added
 - The plugin will now check whether a media entry should be 'marked for deletion' based on its presence in the API calls.
-- Show synchronizaiton jobs can now be scheduled to run at a specific time.
+- Show synchronization jobs can now be scheduled to run at a specific time.
 - You can now select what fields should be updated during a sync. 
 
 ## 3.1.1 - 2021-06-03

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "moon/pbs-media-manager-craft-kenburns",
   "description": "Media Manager 3 for PBS API",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "craft-plugin",
   "keywords": ["craftcms", "pbs", "media-manager"],
   "license": "MIT",
@@ -9,10 +9,14 @@
     {
       "name": "Paper Tiger",
       "homepage": "https://papertiger.com"
+    },
+    {
+      "name": "Good Work",
+      "homepage": "https://simplygoodwork.com"
     }
   ],
   "support": {
-    "email": "info@papertiger.com",
+    "email": "dev@simplygoodwork.com",
     "issues": "https://github.com/pbs/pbs-media-manager-craft-kenburns/issues",
     "source": "https://github.com/pbs/pbs-media-manager-craft-kenburns/blob/main/README.md",
     "docs": "https://github.com/pbs/pbs-media-manager-craft-kenburns/blob/main/README.md"

--- a/src/MediaManager.php
+++ b/src/MediaManager.php
@@ -105,9 +105,9 @@ class MediaManager extends Plugin
     public function afterSaveSettings()
     {
         ApiColumnFieldsHelper::process();
-        FieldLayoutHelper::process();
+        //FieldLayoutHelper::process();
         ShowApiColumnFieldsHelper::process();
-        ShowFieldLayoutHelper::process();
+        //ShowFieldLayoutHelper::process();
         OldSettingsHelper::process();
     }
 

--- a/src/jobs/MediaSync.php
+++ b/src/jobs/MediaSync.php
@@ -216,10 +216,11 @@ class MediaSync extends BaseJob
                             if( $tag ) {
                                 array_push( $siteTags, $tag->id );
                             }
+
                         }
-
+												$this->siteTags = $siteTags;
                         $defaultFields[ $siteTagFieldHandle ] = $siteTags;
-
+												
                     break;
                     case 'film_tags':
 
@@ -253,7 +254,8 @@ class MediaSync extends BaseJob
                                 $filmTags[] = $film->id;
                             }
                         }
-
+												
+												$this->filmTags = $filmTags;
                         $defaultFields[ $filmTagFieldHandle ] = $filmTags;
 
                     break;
@@ -282,6 +284,7 @@ class MediaSync extends BaseJob
                             }
                         }
 
+												$this->topicTags = $topicTags;
                         $defaultFields[ $topicTagFieldHandle ] = $topicTags;
 
                     break;

--- a/src/jobs/MediaSync.php
+++ b/src/jobs/MediaSync.php
@@ -116,6 +116,8 @@ class MediaSync extends BaseJob
                 $availabilities->public->start,
                 $availabilities->public->end
             );
+						
+						$isNew = !$existingEntry;
 
             // Set default field Values
             $defaultFields = [];
@@ -123,7 +125,7 @@ class MediaSync extends BaseJob
             // Set field values based on API Column Fields on settings
             $apiColumnFields = SettingsHelper::get( 'apiColumnFields' );
 						
-						if($this->fieldsToSync === '*' || in_array('title', $this->fieldsToSync)) {
+						if($this->fieldsToSync === '*' || in_array('title', $this->fieldsToSync) || $isNew ){
 								$entry->title = $assetAttributes->title;
 						}
 
@@ -132,7 +134,7 @@ class MediaSync extends BaseJob
                 $apiField = $apiColumnField[ 0 ];
 								
 								// ensure the field to be updated from MM Settings is included in the fieldsToSync array
-								if($this->fieldsToSync !== '*' && !in_array($apiField, $this->fieldsToSync) ) {
+								if(!$isNew && ($this->fieldsToSync !== '*' && !in_array($apiField, $this->fieldsToSync)) ) {
 									continue;
 								}
 							
@@ -248,9 +250,7 @@ class MediaSync extends BaseJob
                             }
 
                             if( $film ) {
-                                if( $tag ) {
-                                    array_push( $filmTags, $film->id );
-                                }
+                                $filmTags[] = $film->id;
                             }
                         }
 

--- a/src/jobs/ShowEntriesSync.php
+++ b/src/jobs/ShowEntriesSync.php
@@ -12,6 +12,9 @@ namespace papertiger\mediamanager\jobs;
 
 use Craft;
 use craft\db\Query;
+use craft\errors\ElementNotFoundException;
+use craft\helpers\DateTimeHelper;
+use craft\helpers\Json;
 use craft\queue\BaseJob;
 use craft\elements\Entry;
 use craft\elements\Asset;
@@ -20,9 +23,11 @@ use craft\helpers\FileHelper;
 use craft\helpers\ElementHelper;
 use craft\helpers\Assets as AssetHelper;
 
+use DateTime;
 use papertiger\mediamanager\MediaManager;
 use papertiger\mediamanager\helpers\SettingsHelper;
 use papertiger\mediamanager\helpers\SynchronizeHelper;
+use yii\base\Exception;
 
 
 class ShowEntriesSync extends BaseJob
@@ -58,12 +63,20 @@ class ShowEntriesSync extends BaseJob
     // =========================================================================
     
     private $dateWithMs = 'Y-m-d\TH:i:s.uP';
-
+		
+		private $_availabilityProcessed = false;
+		private $availabilityPassport = 0;
+		private $availabilityPublic = 0;
 
     // Public Methods
     // =========================================================================
-
-    public function execute( $queue )
+	
+	/**
+	 * @throws Exception
+	 * @throws \Throwable
+	 * @throws ElementNotFoundException
+	 */
+	public function execute( $queue )
     {
         $this->apiBaseUrl     = SettingsHelper::get( 'apiBaseUrl' );
         $this->sectionId      = SynchronizeHelper::getShowSectionId(); // SECTION_ID
@@ -75,11 +88,12 @@ class ShowEntriesSync extends BaseJob
         $this->logFile        = '@storage/logs/sync.log'; // LOG_FILE
 
         $url      = $this->generateAPIUrl( $this->apiKey );
-        $showEntry = $this->fetchShowEntry( $url );
+        $showEntry = $this->fetchShowEntry($url, '');
+				
+        $showAttributes = $showEntry->data->attributes;
 
-        $showAttributes = $showEntry->attributes;
-
-        $existingEntry       = $this->findExistingShowEntry( $showEntry->id );
+        $existingEntry       = $this->findExistingShowEntry( $showEntry->data->id );
+				$isNew = !$existingEntry;
         $entry               = $this->chooseOrCreateShowEntry( $showAttributes->title, $existingEntry );
 
         // Set default field Values
@@ -93,7 +107,7 @@ class ShowEntriesSync extends BaseJob
             $apiField = $apiColumnField[ 0 ];
 	
 		        // ensure the field to be updated from MM Settings is included in the fieldsToSync array
-		        if($this->fieldsToSync !== '*' && !in_array($apiField, $this->fieldsToSync) ) {
+		        if(!$isNew && ($this->fieldsToSync !== '*' && !in_array($apiField, $this->fieldsToSync))) {
 			        continue;
 		        }
 
@@ -147,7 +161,7 @@ class ShowEntriesSync extends BaseJob
                     $defaultFields[ SynchronizeHelper::getShowLastSyncedField() ] = new \DateTime( 'now' );
                 break;
                 case 'show_media_manager_id':
-                    $defaultFields[ SynchronizeHelper::getShowMediaManagerIdField() ] = $showEntry->id;
+                    $defaultFields[ SynchronizeHelper::getShowMediaManagerIdField() ] = $showEntry->data->id;
                 break;
 	              case 'show_site_url':
 									if(isset( $showAttributes->links) && is_array($showAttributes->links)){
@@ -158,7 +172,6 @@ class ShowEntriesSync extends BaseJob
                         }
                     }
 								break;
-									
 	              case 'available_for_purchase':
 									$availableForPurchase = 0;
 									$purchasablePlatforms = ['itunes', 'amazon', 'buy-dvd', 'roku', 'apple-tv', 'ios'];
@@ -174,7 +187,6 @@ class ShowEntriesSync extends BaseJob
 												$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $availableForPurchase;
                     }
 								break;
-									
                 case 'description_long':
                     // Only if new entry add description
                     if( !$existingEntry ) {
@@ -198,7 +210,6 @@ class ShowEntriesSync extends BaseJob
                         $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $showAttributes->episodes_count;
                     }
                 break;
-
                 case 'featured_preview':
 
                     $mediaManagerEntries = [];
@@ -211,7 +222,6 @@ class ShowEntriesSync extends BaseJob
                     }
 
                 break;
-
                 case 'links':
 
                     if( isset( $showAttributes->links ) && is_array( $showAttributes->links ) ) {
@@ -231,7 +241,16 @@ class ShowEntriesSync extends BaseJob
                     }
 
                 break;
-
+	              case 'stream_with_passport':
+									$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $this->getShowAvailability('availabilityPassport', $showEntry);
+									break;
+									
+		            case 'available_to_public':
+									$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $this->getShowAvailability('availabilityPublic', $showEntry);
+									break;
+									
+								
+									
                 default:
                     $defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $showAttributes->{ $apiField };
                 break;
@@ -270,14 +289,93 @@ class ShowEntriesSync extends BaseJob
         return $this->apiBaseUrl . 'shows/'. $apiKey . '/?platform-slug=bento&platform-slug=partnerplayer';
     }
 
-    private function fetchShowEntry( $url )
+    private function fetchShowEntry($url, $attribute = 'data')
     {
         $client   = Craft::createGuzzleClient();
         $response = $client->get( $url, $this->auth );
-        $response = json_decode( $response->getBody() );
+        $response = Json::decode($response->getBody(), false);
 
-        return $response->data;
+        if($attribute){
+					return $response->{$attribute};
+				}
+				
+        return $response;
     }
+	
+	/**
+	 * @throws \Exception
+	 */
+	private function getShowAvailability(string $attribute, $showEntry): int
+		{
+			// Don't run this twice
+			if($this->_availabilityProcessed){
+				return $this->$attribute;
+			}
+			
+			// There is probably a much cleaner / more straightforward way of doing this
+			// we need to loops through all assets of the show's first season to see if any of them are available for streaming
+			// If any episode in season 1 is available to passport members, then we can say the show is in Passport. If any episode within Season 1 is available to the Public, then we can also say it is "available to everyone".
+			// logic per https://github.com/pbs/pbs-media-manager-craft-plugin/issues/10#issuecomment-1791521258
+			
+			$availableOnPassport = 0;
+			$availableToPublic = 0;
+			
+      // get show's seasons
+      $seasonsUrl = $showEntry->links->seasons;
+      $seasonData = $this->fetchShowEntry($seasonsUrl);
+			if(!$seasonData){
+				 Craft::error('No seasons found for show ' . $showEntry->data->id, __METHOD__);
+				return 0;
+			}
+			
+			// get first season's episodes
+			$firstSeasonIndex = count($seasonData) - 1;
+			$episodesUrl = $seasonData[$firstSeasonIndex]->links->episodes;
+			$episodesData = $this->fetchShowEntry($episodesUrl);
+			
+			if(!$episodesData){
+				Craft::error('No episodes found for season ' . $seasonData[$firstSeasonIndex]->id, __METHOD__);
+				return 0;
+			}
+			
+			foreach($episodesData as $episode){
+				// if we've determined that both are true, we can stop looping
+				if($availableOnPassport && $availableToPublic){
+					continue;
+				}
+				
+				$episodeAssetsUrl = $episode->links->assets;
+				$episodeAssets = $this->fetchShowEntry($episodeAssetsUrl);
+				
+				if(!$episodeAssets) {
+					Craft::error('No assets found for episode ' . $episode->id, __METHOD__);
+					return 0;
+				}
+				
+				foreach($episodeAssets as $asset){
+					if($availableOnPassport && $availableToPublic){
+						continue;
+					}
+					
+					$publicEndDate = new DateTime($asset->attributes->availabilities->public->end) ?? null;
+					$passportEndDate = new DateTime($asset->attributes->availabilities->all_members->end) ?? null;
+					
+					if($publicEndDate instanceof DateTime){
+						$availableToPublic = DateTimeHelper::isInThePast($publicEndDate) ? 0 : 1;
+					}
+					
+					if($passportEndDate instanceof DateTime){
+						$availableOnPassport = DateTimeHelper::isInThePast($passportEndDate) ? 0 : 1;
+					}
+				}
+			}
+			
+			$this->availabilityPassport = $availableOnPassport;
+			$this->availabilityPublic = $availableToPublic;
+			$this->_availabilityProcessed = true;
+			
+			return $this->$attribute;
+		}
     
     private function findExistingShowEntry( $mediaManagerId )
     {

--- a/src/jobs/ShowEntriesSync.php
+++ b/src/jobs/ShowEntriesSync.php
@@ -149,6 +149,32 @@ class ShowEntriesSync extends BaseJob
                 case 'show_media_manager_id':
                     $defaultFields[ SynchronizeHelper::getShowMediaManagerIdField() ] = $showEntry->id;
                 break;
+	              case 'show_site_url':
+									if(isset( $showAttributes->links) && is_array($showAttributes->links)){
+                        foreach($showAttributes->links as $link) {
+                            if($link->profile == 'producer') {
+																$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $link->value;
+														}
+                        }
+                    }
+								break;
+									
+	              case 'available_for_purchase':
+									$availableForPurchase = 0;
+									$purchasablePlatforms = ['itunes', 'amazon', 'buy-dvd', 'roku', 'apple-tv', 'ios'];
+									if(isset( $showAttributes->links) && is_array($showAttributes->links)){
+                        foreach($showAttributes->links as $link) {
+                            if($availableForPurchase || !in_array($link->profile, $purchasablePlatforms)){
+																continue;
+                            }
+														if(in_array($link->profile, $purchasablePlatforms)){
+																$availableForPurchase = 1;
+														}
+                        }
+												$defaultFields[ SynchronizeHelper::getApiField( $apiField, 'showApiColumnFields' ) ] = $availableForPurchase;
+                    }
+								break;
+									
                 case 'description_long':
                     // Only if new entry add description
                     if( !$existingEntry ) {

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -10,7 +10,6 @@
 {% set tabs = [
     { label: 'Base', url: '#settings-tab-base' },
     { label: 'API Column & Fields', url: '#settings-tab-api-column-fields' },
-    { label: 'Field Layout', url: '#settings-tab-field-layout' },
     { label: 'Synchronize', url: '#settings-tab-synchronize' }
 ] %}
 
@@ -32,7 +31,7 @@
         ul.errors { list-style: none; padding-left: 0 !important;  }
         ul.errors li { list-style-type: none !important;  }
         .hud.info-hud { max-width: 300px; }
-        
+
         {% if not isCraft35 %}
             .flex .field.flex-grow:last-of-type { margin-top: 0 !important; margin-bottom: 7px !important; }
         {% endif %}
@@ -45,7 +44,6 @@
     {% namespace 'settings' %}
         {% include 'mediamanager/settings/_base' %}
         {% include 'mediamanager/settings/_apicolumnfields' %}
-        {% include 'mediamanager/settings/_fieldlayout' %}
         {% include 'mediamanager/settings/_synchronize' %}
     {% endnamespace %}
 

--- a/src/templates/settings/_apicolumnfields.twig
+++ b/src/templates/settings/_apicolumnfields.twig
@@ -153,6 +153,14 @@
                         "label":"links"
                     },
                     {
+                        "value": "stream_with_passport",
+                        "label": "Stream with Passport (bool)"
+                    },
+                    {
+                        "value": "available_to_public",
+                        "label": "Available to Public (bool)"
+                    },
+                    {
                         "value":"featured_preview",
                         "label":"featured_preview"
                     },

--- a/src/templates/settings/_apicolumnfields.twig
+++ b/src/templates/settings/_apicolumnfields.twig
@@ -27,7 +27,7 @@
         options: allusers,
         errors: settings.getErrors( 'apiCraftUser' )
     }) }}
-    
+
     {{ forms.textField({
         required: true,
         name: 'apiBaseUrl',
@@ -49,8 +49,8 @@
         rows: settings.apiColumnFields,
         errors: settings.getErrors( 'apiColumnFields' ),
         cols: [
-            { 
-                heading: 'API Field', 
+            {
+                heading: 'API Field',
                 handle: 'apiField',
                 width: '20%',
                 type: 'select',
@@ -63,32 +63,32 @@
                         {"value":"slug","label":"slug"},{"value":"title","label":"title"},{"value":"title_sortable","label":"title_sortable"},{"value":"description_short","label":"description_short"},{"value":"description_long","label":"description_long"},{"value":"object_type","label":"object_type"},{"value":"premiered_on","label":"premiered_on"},{"value":"encored_on","label":"encored_on"},{"value":"is_excluded_from_dfp","label":"is_excluded_from_dfp"},{"value":"duration","label":"duration"},{"value":"content_rating","label":"content_rating"},{"value":"content_rating_descriptor","label":"content_rating_descriptor"},{"value":"can_embed_player","label":"can_embed_player"},{"value":"tags","label":"tags"},{"value":"language","label":"language"},{"value":"funder_message","label":"funder_message"},{"value":"images","label":"images"},{"value":"updated_at","label":"updated_at"},{"value":"countries","label":"countries"},{"value":"geo_profile","label":"geo_profile"},{"value":"topics","label":"topics"},{"value":"platforms","label":"platforms"},{"value":"player_code","label":"player_code"},{"value":"availabilities","label":"availabilities"},{"value":"related_links","label":"related_links"},{"value":"related_promos","label":"related_promos"},{"value":"parent_tree","label":"parent_tree"},{"value":"has_captions","label":"has_captions"}
                 ]
             },
-            { 
-                heading: 'Use existing Craft Field', 
+            {
+                heading: 'Use existing Craft Field',
                 handle: 'existingField',
                 info: 'If selected, you dont need to fill <strong>Craft Field Name</strong>, <strong>Craft Field Handle</strong> and <strong>Craft Field Type</strong>.',
                 width: '20%',
                 type: 'select',
                 options: existingFields
             },
-            { 
-                heading: 'Craft Field Name', 
+            {
+                heading: 'Craft Field Name',
                 handle: 'fieldName',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Handle', 
+            {
+                heading: 'Craft Field Handle',
                 handle: 'fieldHandle',
                 info: 'Make sure field handle is in camelCase format and unique, existing field with same Field Handle will be used if found. If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Type', 
+            {
+                heading: 'Craft Field Type',
                 handle: 'fieldType',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
@@ -113,45 +113,77 @@
         rows: settings.showApiColumnFields,
         errors: settings.getErrors( 'showApiColumnFields' ),
         cols: [
-            { 
-                heading: 'API Field', 
+            {
+                heading: 'API Field',
                 handle: 'apiField',
                 width: '20%',
                 type: 'select',
                 options: [
                     {"label":"— Select Field —"},
-                    {"optgroup":"Special Field","label":"Special Field"},
-                        {"value":"show_images","label":"Images"},{"value":"show_last_synced","label":"Last Synced"},{"value":"show_media_manager_id","label":"Media Manager ID"},
-                    {"optgroup":"From PBS API","label":"From PBS API"},
-                        {"value":"description_short","label":"description_short"},{"value":"description_long","label":"description_long"}
+                    {
+                        "optgroup":"Special Field",
+                        "label":"Special Field"
+                    },
+                    {
+                        "value":"show_images",
+                        "label":"Images"
+                    },
+                    {
+                        "value":"show_last_synced",
+                        "label":"Last Synced"
+                    },
+                    {
+                        "value":"show_media_manager_id",
+                        "label":"Media Manager ID"
+                    },
+                    {
+                        "optgroup":"From PBS API",
+                        "label":"From PBS API"
+                    },
+                    {
+                        "value":"description_short",
+                        "label":"description_short"
+                    },
+                    {
+                        "value":"description_long",
+                        "label":"description_long"
+                    },
+                    {
+                        "value":"show_site_url",
+                        "label":"Show Site URL"
+                    },
+                    {
+                        "value":"available_for_purchase",
+                        "label":"Available for Purchase"
+                    }
                 ]
             },
-            { 
-                heading: 'Use existing Craft Field', 
+            {
+                heading: 'Use existing Craft Field',
                 handle: 'existingField',
                 info: 'If selected, you dont need to fill <strong>Craft Field Name</strong>, <strong>Craft Field Handle</strong> and <strong>Craft Field Type</strong>.',
                 width: '20%',
                 type: 'select',
                 options: existingFields
             },
-            { 
-                heading: 'Craft Field Name', 
+            {
+                heading: 'Craft Field Name',
                 handle: 'fieldName',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Handle', 
+            {
+                heading: 'Craft Field Handle',
                 handle: 'fieldHandle',
                 info: 'Make sure field handle is in camelCase format and unique, existing field with same Field Handle will be used if found. If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',
                 type: 'singleline',
                 placeholder: 'Field Name'
             },
-            { 
-                heading: 'Craft Field Type', 
+            {
+                heading: 'Craft Field Type',
                 handle: 'fieldType',
                 info: 'If <strong>Use existing Craft Field</strong> selected, you dont need to fill this field since it will be ignored.',
                 width: '20%',

--- a/src/templates/settings/_apicolumnfields.twig
+++ b/src/templates/settings/_apicolumnfields.twig
@@ -141,6 +141,22 @@
                         "label":"From PBS API"
                     },
                     {
+                        "value":"premiered_on",
+                        "label":"premiered_on"
+                    },
+                    {
+                        "value":"episodes_count",
+                        "label":"episodes_count"
+                    },
+                    {
+                        "value":"links",
+                        "label":"links"
+                    },
+                    {
+                        "value":"featured_preview",
+                        "label":"featured_preview"
+                    },
+                    {
                         "value":"description_short",
                         "label":"description_short"
                     },

--- a/src/templates/settings/_fieldlayout.twig
+++ b/src/templates/settings/_fieldlayout.twig
@@ -1,123 +1,123 @@
-{% import '_includes/forms' as forms %}
+{#{% import '_includes/forms' as forms %}#}
 
-{% set groups = craft.app.fields.getAllGroups() %}
-{% set settingFields = [] %}
-{% set showSettingFields = [] %}
-{% for tabName, tabFields in settings.fieldLayout %}
-    {% for tabField in tabFields %}
-        {% set settingFields = settingFields | merge( [ tabField ] ) %}
-    {% endfor %}
-{% endfor %}
-{% for tabName, tabFields in settings.showFieldLayout %}
-    {% for tabField in tabFields %}
-        {% set showSettingFields = showSettingFields | merge( [ tabField ] ) %}
-    {% endfor %}
-{% endfor %}
+{#{% set groups = craft.app.fields.getAllGroups() %}#}
+{#{% set settingFields = [] %}#}
+{#{% set showSettingFields = [] %}#}
+{#{% for tabName, tabFields in settings.fieldLayout %}#}
+{#    {% for tabField in tabFields %}#}
+{#        {% set settingFields = settingFields | merge( [ tabField ] ) %}#}
+{#    {% endfor %}#}
+{#{% endfor %}#}
+{#{% for tabName, tabFields in settings.showFieldLayout %}#}
+{#    {% for tabField in tabFields %}#}
+{#        {% set showSettingFields = showSettingFields | merge( [ tabField ] ) %}#}
+{#    {% endfor %}#}
+{#{% endfor %}#}
 
-<div id="tab-field-layout" class="hidden">
-    <style type="text/css">
-        #settings-fieldLayout {
-            opacity: 0;
-            position: absolute;
-            pointer-events: none;
-        }
-    </style>
+{#<div id="tab-field-layout" class="hidden">#}
+{#    <style type="text/css">#}
+{#        #settings-fieldLayout {#}
+{#            opacity: 0;#}
+{#            position: absolute;#}
+{#            pointer-events: none;#}
+{#        }#}
+{#    </style>#}
 
-    <div class="field" style="margin-top: 0;">
-        <div class="heading">
-            <label class="required">Media Section's Field Layout</label>
-        </div>
-        <div class="instructions">
-            <p>Modify media section's field layout based on API Column & Fields in previous tab.</p>
-        </div>
-    </div>
+{#    <div class="field" style="margin-top: 0;">#}
+{#        <div class="heading">#}
+{#            <label class="required">Media Section's Field Layout</label>#}
+{#        </div>#}
+{#        <div class="instructions">#}
+{#            <p>Modify media section's field layout based on API Column & Fields in previous tab.</p>#}
+{#        </div>#}
+{#    </div>#}
 
-    {% if isCraft35 %}
-        {% include 'mediamanager/settings/_fieldlayout/_craft35' %}
-    {% else %}
-        {% include 'mediamanager/settings/_fieldlayout/_oldercraft' %}
-    {% endif %}
+{#    {% if isCraft35 %}#}
+{#        {% include 'mediamanager/settings/_fieldlayout/_craft35' %}#}
+{#    {% else %}#}
+{#        {% include 'mediamanager/settings/_fieldlayout/_oldercraft' %}#}
+{#    {% endif %}#}
 
-    <hr/>
+{#    <hr/>#}
 
-    <div class="field" style="margin-top: 0;">
-        <div class="heading">
-            <label class="required">Show Section's Field Layout</label>
-        </div>
-        <div class="instructions">
-            <p>Modify show section's field layout based on API Column & Fields in previous tab.</p>
-        </div>
-    </div>
+{#    <div class="field" style="margin-top: 0;">#}
+{#        <div class="heading">#}
+{#            <label class="required">Show Section's Field Layout</label>#}
+{#        </div>#}
+{#        <div class="instructions">#}
+{#            <p>Modify show section's field layout based on API Column & Fields in previous tab.</p>#}
+{#        </div>#}
+{#    </div>#}
 
-    {% if isCraft35 %}
-        {% include 'mediamanager/settings/_fieldlayout/_showCraft35' %}
-    {% else %}
-        {% include 'mediamanager/settings/_fieldlayout/_showOldercraft' %}
-    {% endif %}
+{#    {% if isCraft35 %}#}
+{#        {% include 'mediamanager/settings/_fieldlayout/_showCraft35' %}#}
+{#    {% else %}#}
+{#        {% include 'mediamanager/settings/_fieldlayout/_showOldercraft' %}#}
+{#    {% endif %}#}
 
 
-    {% if isCraft35 %}
-        {% set jsSettings1 = {
-            customizableTabs: true,
-            customizableUi: true,
-            elementPlacementInputName: 'fieldLayout[__TAB_NAME__][]'|namespaceInputName,
-        } %}
+{#    {% if isCraft35 %}#}
+{#        {% set jsSettings1 = {#}
+{#            customizableTabs: true,#}
+{#            customizableUi: true,#}
+{#            elementPlacementInputName: 'fieldLayout[__TAB_NAME__][]'|namespaceInputName,#}
+{#        } %}#}
 
-        {% set jsSettings2 = {
-            customizableTabs: true,
-            customizableUi: true,
-            elementPlacementInputName: 'showFieldLayout[__TAB_NAME__][]'|namespaceInputName,
-        } %}
+{#        {% set jsSettings2 = {#}
+{#            customizableTabs: true,#}
+{#            customizableUi: true,#}
+{#            elementPlacementInputName: 'showFieldLayout[__TAB_NAME__][]'|namespaceInputName,#}
+{#        } %}#}
 
-        {% js %}
-            new Craft.FieldLayoutDesigner("#{{ 'fieldlayoutform'|namespaceInputId }}", {{ jsSettings1|json_encode|raw }});
-            new Craft.FieldLayoutDesigner("#{{ 'showfieldlayoutform'|namespaceInputId }}", {{ jsSettings2|json_encode|raw }});
+{#        {% js %}#}
+{#            new Craft.FieldLayoutDesigner("#{{ 'fieldlayoutform'|namespaceInputId }}", {{ jsSettings1|json_encode|raw }});#}
+{#            new Craft.FieldLayoutDesigner("#{{ 'showfieldlayoutform'|namespaceInputId }}", {{ jsSettings2|json_encode|raw }});#}
 
-            var settingsForm = document.getElementById( 'main-form' )
+{#            var settingsForm = document.getElementById( 'main-form' )#}
 
-            settingsForm.onsubmit = function() {
+{#            settingsForm.onsubmit = function() {#}
 
-                var inputs = document.querySelectorAll ('input.placement-input[name^="settings\\[fieldLayout\\]"]' );
-                var inputs_show = document.querySelectorAll ('input.placement-input[name^="settings\\[showFieldLayout\\]"]' );
+{#                var inputs = document.querySelectorAll ('input.placement-input[name^="settings\\[fieldLayout\\]"]' );#}
+{#                var inputs_show = document.querySelectorAll ('input.placement-input[name^="settings\\[showFieldLayout\\]"]' );#}
 
-                [].forEach.call( inputs, function( input ) {
+{#                [].forEach.call( inputs, function( input ) {#}
 
-                    console.log( 'was : ', input.value )
-                    input.value = input.closest( '.fld-field.fld-element' ).getAttribute( 'data-attribute' )
-                    console.log( 'now : ', input.value )
+{#                    console.log( 'was : ', input.value )#}
+{#                    input.value = input.closest( '.fld-field.fld-element' ).getAttribute( 'data-attribute' )#}
+{#                    console.log( 'now : ', input.value )#}
 
-                });
+{#                });#}
 
-                [].forEach.call( inputs_show, function( input ) {
+{#                [].forEach.call( inputs_show, function( input ) {#}
 
-                    console.log( 'was : ', input.value )
-                    input.value = input.closest( '.fld-field.fld-element' ).getAttribute( 'data-attribute' )
-                    console.log( 'now : ', input.value )
+{#                    console.log( 'was : ', input.value )#}
+{#                    input.value = input.closest( '.fld-field.fld-element' ).getAttribute( 'data-attribute' )#}
+{#                    console.log( 'now : ', input.value )#}
 
-                });
+{#                });#}
 
-                settingsForm.submit();
-            }
-        {% endjs %}
-    {% else %}
-        {% js %}
-            window.addEventListener('load', function() {
-                new Craft.FieldLayoutDesigner('.customshowfieldlayout', {
-                    customizableTabs: true,
-                    fieldInputName: '{{ "showFieldLayout[__TAB_NAME__][]"|namespaceInputName|e("js") }}',
-                    requiredFieldInputName: '{{ "requiredFields[]"|namespaceInputName|e("js") }}'
-                });
-            });
-        {% endjs %}
-        {% js %}
-            window.addEventListener('load', function() {
-                new Craft.FieldLayoutDesigner('.customfieldlayout', {
-                    customizableTabs: true,
-                    fieldInputName: '{{ "fieldLayout[__TAB_NAME__][]"|namespaceInputName|e("js") }}',
-                    requiredFieldInputName: '{{ "requiredFields[]"|namespaceInputName|e("js") }}'
-                });
-            });
-        {% endjs %}
-    {% endif %}
+{#                settingsForm.submit();#}
+{#            }#}
+{#        {% endjs %}#}
+{#    {% else %}#}
+{#        {% js %}#}
+{#            window.addEventListener('load', function() {#}
+{#                new Craft.FieldLayoutDesigner('.customshowfieldlayout', {#}
+{#                    customizableTabs: true,#}
+{#                    fieldInputName: '{{ "showFieldLayout[__TAB_NAME__][]"|namespaceInputName|e("js") }}',#}
+{#                    requiredFieldInputName: '{{ "requiredFields[]"|namespaceInputName|e("js") }}'#}
+{#                });#}
+{#            });#}
+{#        {% endjs %}#}
+{#        {% js %}#}
+{#            window.addEventListener('load', function() {#}
+{#                new Craft.FieldLayoutDesigner('.customfieldlayout', {#}
+{#                    customizableTabs: true,#}
+{#                    fieldInputName: '{{ "fieldLayout[__TAB_NAME__][]"|namespaceInputName|e("js") }}',#}
+{#                    requiredFieldInputName: '{{ "requiredFields[]"|namespaceInputName|e("js") }}'#}
+{#                });#}
+{#            });#}
+{#        {% endjs %}#}
+{#    {% endif %}#}
 
-</div>
+{#</div>#}


### PR DESCRIPTION
### Fixed
- Fixed missing property setters in the MediaSync job that prevented the 'check for changes' feature from working properly ([e4100dc](https://github.com/pbs/pbs-media-manager-craft-kenburns/commit/e4100dc53090e2c6f20a23e6b2288d3efe9e86a9))

### Changed 
- **New** Media entries and Show entries added during a sync will always synchronize all fields, regardless of what fields were selected for sync.
- Plugin settings no longer handles field layouts for Media or Show sections. 
### Added
- Added more API attributes to the list of fields that can be synchronized to Show entries.
- Show Entry sync jobs can now sync the Passport availability and public availability flags.