### PR TITLE
v3.3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.4.2 = 2023-12-13
+### Fixed
+- Fix show availability sync that was including assets like clips and trailers when determining a show's public availability
+
 ## 3.3.4.1 - 2023-12-12
 ### Fixed
 - Fix show sync logic that was incorrectly returning before show availability could be determined.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "moon/pbs-media-manager-craft-kenburns",
   "description": "Media Manager 3 for PBS API",
-  "version": "3.3.4.1",
+  "version": "3.3.4.2",
   "type": "craft-plugin",
   "keywords": ["craftcms", "pbs", "media-manager"],
   "license": "MIT",

--- a/src/jobs/ShowEntriesSync.php
+++ b/src/jobs/ShowEntriesSync.php
@@ -360,7 +360,7 @@ class ShowEntriesSync extends BaseJob
 				}
 
 				$episodeAssetsUrl = $episode->links->assets;
-				$episodeAssets = $this->fetchShowEntry($episodeAssetsUrl);
+				$episodeAssets = $this->fetchShowEntry($episodeAssetsUrl, 'data', ['type' => 'full_length']);
 
 				if(!$episodeAssets) {
 					continue;


### PR DESCRIPTION
### Fixed
- Fix show availability sync that was including assets like clips and trailers when determining a show's public availability